### PR TITLE
Prevent deprecation warnings in React 15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "bugs": "https://github.com/jquery-support/react-globalize/issues",
   "peerDependencies": {
     "globalize": ">= 1.0.0",
-    "react": "^0.13 || ^0.14 || ^15.0.0"
+    "react": "^0.13 || ^0.14 || ^15.0.0 || 15.x"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.6",
@@ -42,6 +42,7 @@
     "chai": "^3.5.0",
     "cldr-data": ">=25",
     "cldrjs": "^0.4.3",
+    "create-react-class": "^15.5.2",
     "enzyme": "2.2.0",
     "eslint": "^1.10.3",
     "eslint-config-defaults": "^7.1.1",

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,3 +1,4 @@
+import reactCreateClass from "./react-create-class";
 import React from "react";
 import Globalize from "globalize";
 
@@ -22,7 +23,7 @@ function generator(fn, localPropNames, options) {
     };
     var globalizePropNames = commonPropNames.concat(localPropNames);
 
-    return React.createClass({
+    return reactCreateClass({
         displayName: Fn,
         componentWillMount: function() {
             this.setup(this.props);

--- a/src/react-create-class.js
+++ b/src/react-create-class.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+const [major, minor] = React.version.split(".");
+
+const REACT15 = major === "15";
+const REACT155 = REACT15 && minor >= 5;
+
+let reactCreateClass;
+if (REACT155) {
+    reactCreateClass = require("create-react-class");
+} else {
+    reactCreateClass = React.createClass;
+}
+
+export default reactCreateClass;


### PR DESCRIPTION
**Problem:** React 15.5 deprecated `React.createClass` and will now throw errors.

**Solution:** The simplest solution is to use `create-react-class` and check the React version.
