### PR TITLE
Don't use destructuring in react version check

### DIFF
--- a/src/react-create-class.js
+++ b/src/react-create-class.js
@@ -1,6 +1,8 @@
 import React from "react";
 
-var [major, minor] = React.version.split(".");
+var versions = React.version.split(".");
+var major = versions[0];
+var minor = versions[1];
 
 var REACT15 = major === "15";
 var REACT155 = REACT15 && minor >= 5;


### PR DESCRIPTION
**Problem:** Array destructuring throwing errors in older versions of Chrome

**Reason:** This lib looks like it uses babel... but it doesn't.

**Solution:** Don't use destructuring.