### PR TITLE
Make globalize and react actual dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "license": "MIT",
   "repository": "jquery-support/react-globalize",
   "bugs": "https://github.com/jquery-support/react-globalize/issues",
-  "peerDependencies": {
-    "globalize": ">= 1.0.0",
+  "dependencies": {
+    "globalize": "^1.0.0",
     "react": "^16.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I think it's safe by now to make globalize and react actual dependencies (not peer dependencies) given npm improvements over the past years wrt flatten installation and the specific range globalize ^1.0.0 and react ^16.0.0 on version 1.x.